### PR TITLE
[IE-74] Run all paragraphs in Zeppelin tutorial fails

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/CompilingInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/CompilingInterpreter.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.spark;
 
 import com.gigaspaces.spark.utils.StringCompiler;
 import org.apache.zeppelin.interpreter.*;
+import org.apache.zeppelin.scheduler.Scheduler;
 import scala.collection.Iterator;
 
 import java.io.File;
@@ -55,6 +56,17 @@ public class CompilingInterpreter extends Interpreter {
 
     @Override
     public void close() {
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        // reuse Spark scheduler to make sure %def jobs are run sequentially with %spark ones
+        for (Interpreter intp : getInterpreterGroup()) {
+            if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
+                return intp.getScheduler();
+            }
+        }
+        throw new InterpreterException("Can't find SparkInterpreter");
     }
 
     @Override


### PR DESCRIPTION
Recovered the fix #5 that was reverted at 81c1f74
